### PR TITLE
Update installer, continued

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /dist
 /tests/.tmp
 /addins/build
-/scripts/vendor
+/vendor
 
 # Ignore temporary Excel files
 **/~$*

--- a/README.md
+++ b/README.md
@@ -4,8 +4,27 @@ A package manager and build tool for VBA.
 
 ## Installation
 
-1. Download and install the [latest release](https://github.com/vba-blocks/vba-blocks/releases) for your platform (Windows or Mac)
-2. :rocket: You're ready to go! Open a new command-line session (cmd / terminal) and try `vba-blocks help`
+For Windows:
+
+Open powershell and run the following to install vba-blocks:
+
+```shellsession
+> iwr https://vba-blocks.com/install.ps1 | iex
+```
+
+For Mac:
+
+Open terminal and run the following to install vba-blocks:
+
+```shellsession
+$ curl -fsSL https://vba-blocks.com/install.sh | sh
+```
+
+:rocket: You're ready to go! Open a new command-line session (cmd / terminal) and try:
+
+```shellsession
+$ vba-blocks --help
+```
 
 ## Usage
 
@@ -13,60 +32,88 @@ A package manager and build tool for VBA.
 
 Create a new folder with a blank/generated vba-blocks project inside
 
+Create a folder "project-name" with a blank xlsm project:
+
+```shellsession
+$ vba-blocks new project-name.xlsm
 ```
-# Create a folder "project-name" with a blank xlsm project
-> vba-blocks new project-name.xlsm
 
-# (equivalent to above)
-> vba-blocks new project-name --target xlsm
+(equivalent to above)
 
-# Create a folder "from-existing" with a project from an existing workbook
-> vba-blocks new from-existing --from existing.xlsm
+```shellsession
+$ vba-blocks new project-name --target xlsm
+```
 
-# Create a blank package for sharing as a library between projects
-> vba-blocks new json-converter --package
+Create a folder "from-existing" with a project from an existing workbook:
+
+```shellsession
+$ vba-blocks new from-existing --from existing.xlsm
+```
+
+Create a blank package for sharing as a library between projects:
+
+```shellsession
+$ vba-blocks new json-converter --package
 ```
 
 ### `init`
 
 Create a blank/generated vba-blocks project in the current folder
 
+Create a blank xlsm project with the current folder's name:
+
+```shellsession
+$ vba-blocks init --target xlsm
 ```
-# Create a blank xlsm project with current folder's name
-> vba-blocks init --target xlsm
 
-# Create a project from an existing workbook
-> vba-blocks init --from existing.xlsm
+Create a project from an existing workbook:
 
-# Create a blank package
-> vba-blocks init --package
+```shellsession
+$ vba-blocks init --from existing.xlsm
+```
+
+Create a blank package:
+
+```shellsession
+$ vba-blocks init --package
 ```
 
 ### `build`
 
 Build an Excel workbook from the project's source. The built file is located in the `build/` folder and if a previously built file is found it is moved to `/.backup` to protect against losing any previously saved work.
 
+Build a project:
+
+```shellsession
+$ vba-blocks build
 ```
-# Build a project
-> vba-blocks build
 
-# Build and open a project for editing
-> vba-blocks build --open
+Build and open a project for editing:
 
-# Build a package using a blank target
-> vba-blocks build --target xlsm
+```shellsession
+$ vba-blocks build --open
+```
+
+Build a package using a blank target:
+
+```shellsession
+$ vba-blocks build --target xlsm
 ```
 
 ### `export`
 
 Once you've completed your edits and are ready to commit your changes, export your project with `vba-blocks export`.
 
-```
-# Export a project
-> vba-blocks export
+Export a project:
 
-# Export a previously built package
-> vba-blocks export --target xlsm
+```shellsession
+$ vba-blocks export
+```
+
+Export a previously-built package:
+
+```shellsession
+$ vba-blocks export --target xlsm
 ```
 
 ### `run`
@@ -83,10 +130,9 @@ Public Function RunTests(Value As Variant) As String
 End Function
 ```
 
-```
-> vba-blocks run build/example.xlsm Tests.RunTests
+```shellsession
+$ vba-blocks run build/example.xlsm Tests.RunTests
 Howdy!
-
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -4,27 +4,8 @@ A package manager and build tool for VBA.
 
 ## Installation
 
-For Windows:
-
-Open powershell and run the following to install vba-blocks:
-
-```shellsession
-> iwr https://vba-blocks.com/install.ps1 | iex
-```
-
-For Mac:
-
-Open terminal and run the following to install vba-blocks:
-
-```shellsession
-$ curl -fsSL https://vba-blocks.com/install.sh | sh
-```
-
-:rocket: You're ready to go! Open a new command-line session (cmd / terminal) and try:
-
-```shellsession
-$ vba-blocks --help
-```
+1. Download and install the [latest release](https://github.com/vba-blocks/vba-blocks/releases) for your platform (Windows or Mac)
+2. :rocket: You're ready to go! Open a new command-line session (cmd / terminal) and try `vba-blocks help`
 
 ## Usage
 

--- a/addins/src/Build.bas
+++ b/addins/src/Build.bas
@@ -174,11 +174,10 @@ End Function
 
 Private Function InArray(Value As Variant, Values As Variant) As Boolean
     Dim i As Long
-    For i = UBound(Values) To UBound(Values)
+    For i = LBound(Values) To UBound(Values)
         If Values(i) = Value Then
             InArray = True
             Exit Function
         End If
     Next i
-
 End Function

--- a/bin/vba
+++ b/bin/vba
@@ -5,5 +5,5 @@ case `uname` in
   *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
 esac
 
-"$basedir/../node" --no-warnings "$basedir/../lib/vba-blocks.js" "$@"
+"$basedir/../vendor/node" --no-warnings "$basedir/../lib/vba-blocks.js" "$@"
 exit $?

--- a/bin/vba-blocks
+++ b/bin/vba-blocks
@@ -5,5 +5,5 @@ case `uname` in
   *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
 esac
 
-"$basedir/../node" --no-warnings "$basedir/../lib/vba-blocks.js" "$@"
+"$basedir/../vendor/node" --no-warnings "$basedir/../lib/vba-blocks.js" "$@"
 exit $?

--- a/bin/vba-blocks.cmd
+++ b/bin/vba-blocks.cmd
@@ -1,0 +1,1 @@
+"%~dp0\..\vendor\node.exe" --no-warnings "%~dp0\..\lib\vba-blocks.js" %*

--- a/bin/vba-blocks.cmd
+++ b/bin/vba-blocks.cmd
@@ -1,1 +1,2 @@
+@echo off
 "%~dp0\..\vendor\node.exe" --no-warnings "%~dp0\..\lib\vba-blocks.js" %*

--- a/bin/vba-blocks.ps1
+++ b/bin/vba-blocks.ps1
@@ -1,5 +1,5 @@
 #!/usr/bin/env pwsh
 $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
 
-& "$basedir/../node.exe" --no-warnings "$basedir/../lib/vba-blocks.js" $args
+& "$basedir/../vendor/node.exe" --no-warnings "$basedir/../lib/vba-blocks.js" $args
 exit $LASTEXITCODE

--- a/bin/vba.cmd
+++ b/bin/vba.cmd
@@ -1,0 +1,1 @@
+"%~dp0\..\vendor\node.exe" --no-warnings "%~dp0\..\lib\vba-blocks.js" %*

--- a/bin/vba.cmd
+++ b/bin/vba.cmd
@@ -1,1 +1,2 @@
+@echo off
 "%~dp0\..\vendor\node.exe" --no-warnings "%~dp0\..\lib\vba-blocks.js" %*

--- a/bin/vba.ps1
+++ b/bin/vba.ps1
@@ -1,5 +1,5 @@
 #!/usr/bin/env pwsh
 $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
 
-& "$basedir/../node.exe" --no-warnings "$basedir/../lib/vba-blocks.js" $args
+& "$basedir/../vendor/node.exe" --no-warnings "$basedir/../lib/vba-blocks.js" $args
 exit $LASTEXITCODE

--- a/scripts/bin/vba-blocks.cmd
+++ b/scripts/bin/vba-blocks.cmd
@@ -1,1 +1,0 @@
-"%~dp0\..\node.exe" --no-warnings "%~dp0\..\lib\vba-blocks.js" %*

--- a/scripts/bin/vba.cmd
+++ b/scripts/bin/vba.cmd
@@ -1,1 +1,0 @@
-"%~dp0\..\node.exe" --no-warnings "%~dp0\..\lib\vba-blocks.js" %*

--- a/scripts/create-packages.js
+++ b/scripts/create-packages.js
@@ -23,7 +23,7 @@ async function main() {
 }
 
 async function windows() {
-  const file = join(dist, `vba-blocks-v${version}-win.zip`);
+  const file = join(dist, `vba-blocks-win.zip`);
   const input = getInput('win32');
 
   const exe = join(root, 'scripts/vendor', `node-${node_version}`, 'node.exe');
@@ -33,7 +33,7 @@ async function windows() {
 }
 
 async function mac() {
-  const file = join(dist, `vba-blocks-v${version}-mac.zip`);
+  const file = join(dist, `vba-blocks-mac.zip`);
   const input = getInput('darwin');
 
   const exe = join(root, 'scripts/vendor', `node-${node_version}`, 'node');

--- a/scripts/create-packages.js
+++ b/scripts/create-packages.js
@@ -7,7 +7,6 @@ const {
   versions: { node: node_version }
 } = require('./ensure-vendor');
 
-const { version } = require('../package.json');
 const root = join(__dirname, '../');
 const dist = join(root, 'dist');
 
@@ -33,13 +32,13 @@ async function windows() {
 }
 
 async function mac() {
-  const file = join(dist, `vba-blocks-mac.zip`);
+  const file = join(dist, `vba-blocks-mac.tar.gz`);
   const input = getInput('darwin');
 
   const exe = join(root, 'scripts/vendor', `node-${node_version}`, 'node');
   input[exe] = 'node';
 
-  await zip(input, file);
+  await zip(input, file, 'tar', { gzip: true });
 }
 
 function getInput(platform) {
@@ -69,11 +68,11 @@ function getInput(platform) {
   return input;
 }
 
-async function zip(input, dest) {
+async function zip(input, dest, type = 'zip', options = {}) {
   return new Promise((resolve, reject) => {
     try {
       const output = createWriteStream(dest);
-      const archive = createArchive('zip');
+      const archive = createArchive(type, options);
 
       output.on('close', resolve);
       output.on('error', reject);

--- a/scripts/ensure-vendor.js
+++ b/scripts/ensure-vendor.js
@@ -1,13 +1,13 @@
 const { promisify } = require('util');
-const { join, dirname } = require('path');
+const { join, dirname, basename } = require('path');
 const { get: httpsGet } = require('https');
+const { createWriteStream } = require('fs');
 const { ensureDir, pathExists, remove } = require('fs-extra');
 const tmpDir = promisify(require('tmp').dir);
 const decompress = require('decompress');
 
 const node_version = 'v10.15.3';
-const vendor = join(__dirname, 'vendor');
-const node = join(vendor, `node-${node_version}`);
+const vendor = join(__dirname, '../vendor');
 
 main().catch(err => {
   console.error(err);
@@ -19,7 +19,7 @@ async function main() {
 }
 
 async function downloadNode() {
-  if (await pathExists(node)) return;
+  if (await pathExists(join(vendor))) return;
 
   const base = `https://nodejs.org/dist/${node_version}/`;
   const windows = `node-${node_version}-win-x86.zip`;
@@ -40,13 +40,13 @@ async function downloadNode() {
     return file;
   };
 
-  await ensureDir(node);
+  await ensureDir(vendor);
   await Promise.all([
-    decompress(join(dir, windows), node, {
+    decompress(join(dir, windows), vendor, {
       filter: file => /node\.exe$/.test(file.path),
       map: filename
     }),
-    decompress(join(dir, mac), node, {
+    decompress(join(dir, mac), vendor, {
       filter: file => /node$/.test(file.path),
       map: filename
     })

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -42,8 +42,8 @@ async function main() {
 
   console.log('Uploading packages');
   await Promise.all([
-    uploadAsset(join(__dirname, '../dist', `vba-blocks-v${version}-win.zip`), release),
-    uploadAsset(join(__dirname, '../dist', `vba-blocks-v${version}-mac.zip`), release)
+    uploadAsset(join(__dirname, '../dist', `vba-blocks-win.zip`), release),
+    uploadAsset(join(__dirname, '../dist', `vba-blocks-mac.zip`), release)
   ]);
 
   console.log('Done!');

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -43,7 +43,7 @@ async function main() {
   console.log('Uploading packages');
   await Promise.all([
     uploadAsset(join(__dirname, '../dist', `vba-blocks-win.zip`), release),
-    uploadAsset(join(__dirname, '../dist', `vba-blocks-mac.zip`), release)
+    uploadAsset(join(__dirname, '../dist', `vba-blocks-mac.tar.gz`), release)
   ]);
 
   console.log('Done!');

--- a/src/actions/build.ts
+++ b/src/actions/build.ts
@@ -57,7 +57,7 @@ export default async function build(options: BuildOptions = {}): Promise<string>
         No default target(s) found for project.
 
         Use --target TYPE for a blank target
-        or specify [target] or [targets] in vba-block.toml.
+        or specify 'project.target' in vba-block.toml.
       `
     );
   }

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -159,9 +159,9 @@ export async function writeManifest(manifest: Manifest, dir: string) {
 
   value.src = {};
   manifest.src.forEach(source => {
-    let { path, optional } = source;
+    let { name, path, optional } = source;
     path = relative(manifest.dir, path);
-    value.src[source.name] = optional ? { path, optional } : path;
+    value.src[name] = optional ? { path, optional } : path;
   });
 
   if (manifest.target) {
@@ -185,7 +185,11 @@ export async function writeManifest(manifest: Manifest, dir: string) {
     throw new Error(`writeManifest does not currently support dependencies`);
   }
   if (manifest.references.length) {
-    throw new Error(`writeManifest does not currently support references`);
+    value.references = {};
+    manifest.references.forEach(reference => {
+      let { name, version, guid, optional } = reference;
+      value.references[name] = optional ? { version, guid, optional } : { version, guid };
+    });
   }
 
   const toml = await convertToToml(value);

--- a/src/project.ts
+++ b/src/project.ts
@@ -77,7 +77,7 @@ export async function fetchDependencies(project: FetchProject): Promise<Manifest
 
       return manifest;
     },
-    { progress: env.reporter.progress('Fetching Dependencies') }
+    { progress: env.reporter.progress('Fetching dependencies') }
   );
 
   return manifests;

--- a/tests/__helpers__/execute.ts
+++ b/tests/__helpers__/execute.ts
@@ -35,8 +35,8 @@ export async function execute(
   cwd: string,
   command: string
 ): Promise<{ stdout: string; stderr: string }> {
-  const bin = resolve(__dirname, '../../dist/unpacked/bin/vba-blocks');
-  const result = await exec(`${bin} ${command}`, { cwd });
+  const bin = resolve(__dirname, '../../lib/vba-blocks');
+  const result = await exec(`node --no-warnings ${bin} ${command}`, { cwd });
 
   // Give Office time to clean up
   await wait();

--- a/tests/__helpers__/execute.ts
+++ b/tests/__helpers__/execute.ts
@@ -35,8 +35,8 @@ export async function execute(
   cwd: string,
   command: string
 ): Promise<{ stdout: string; stderr: string }> {
-  const bin = resolve(__dirname, '../../lib/vba-blocks');
-  const result = await exec(`node --no-warnings ${bin} ${command}`, { cwd });
+  const bin = resolve(__dirname, '../../bin/vba');
+  const result = await exec(`${bin} ${command}`, { cwd });
 
   // Give Office time to clean up
   await wait();

--- a/tests/__snapshots__/excel.e2e.ts.snap
+++ b/tests/__snapshots__/excel.e2e.ts.snap
@@ -102,6 +102,9 @@ ThisWorkbook = \\"src/ThisWorkbook.cls\\"
 
 Add the following to the [src] section:
 Validation = \\"src/Validation.bas\\"
+
+Add the following to the [references] section:
+VBIDE = { version = \\"5.3\\", guid = \\"{0002E157-0000-0000-C000-000000000046}\\" }
 "
 `;
 
@@ -166,6 +169,9 @@ ThisWorkbook = \\"src/ThisWorkbook.cls\\"
 
 Add the following to the [src] section:
 Validation = \\"src/Validation.bas\\"
+
+Add the following to the [references] section:
+VBIDE = { version = \\"5.3\\", guid = \\"{0002E157-0000-0000-C000-000000000046}\\" }
 "
 `;
 
@@ -227,6 +233,12 @@ Sheet2 = \\"src/Sheet2.cls\\"
 Sheet3 = \\"src/Sheet3.cls\\"
 ThisWorkbook = \\"src/ThisWorkbook.cls\\"
 Validation = \\"src/Validation.bas\\"
+
+[references]
+
+[references.VBIDE]
+version = \\"5.3\\"
+guid = \\"{0002E157-0000-0000-C000-000000000046}\\"
 ",
 }
 `;


### PR DESCRIPTION
Going to follow the lead / directly copy deno with a simple user installer and add support for brew and chocolatey/scoop later. Also want to approximate directory structure used by Electron + Squirrel for future compatibility.

References:
https://github.com/denoland/deno_install
https://github.com/denoland/deno_install/issues/40

  | Windows | macOS
-- | -- | --
bin dir | C:\Users\me\AppData\Roaming\vba-blocks\ | /Users/me/.local/bin/
cache dir | C:\Users\me\AppData\Local\vba-blocks\ | /Users/me/Library/Caches/vba-blocks/

  | Windows | macOS
-- | -- | --
bin dir | %appdata%\vba-blocks\ | $HOME/.local/bin/
cache dir | %localappdata%\vba-blocks\ | $HOME/Library/Caches/vba-blocks/

(Most of this work will likely happen in https://github.com/vba-blocks/installer)