### PR TITLE
Transform for EditorConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "date-fns": "^2",
     "debug": "^4",
     "decompress": "^4",
+    "editorconfig": "^0.15.3",
     "env-paths": "^2",
     "fs-extra": "^7",
     "isomorphic-git": "^0.58",

--- a/src/actions/init.ts
+++ b/src/actions/init.ts
@@ -68,6 +68,18 @@ export default async function init(options: InitOptions) {
       join(dir, '.gitattributes'),
       `* text=auto\n*.bas text eol=crlf\n*.cls text eol=crlf`
     );
+    await writeFile(
+      join(dir, '.editorconfig'),
+      dedent`
+        [*]
+        trim_trailing_whitespace = true
+        insert_final_newline = true
+        charset = utf-8
+
+        [*.{bas,cls}]
+        end_of_line = crlf
+      `
+    );
   }
 
   const project = await initProject(name, dir, {

--- a/src/build/transform-build-graph.ts
+++ b/src/build/transform-build-graph.ts
@@ -1,21 +1,12 @@
-import { BY_LINE } from '../utils/text';
+import asyncFlow from '../utils/async-flow';
 import { BuildGraph } from './build-graph';
+import * as editorConfig from './transforms/editor-config';
 
-export async function toCompiled(graph: BuildGraph): Promise<BuildGraph> {
-  return graph;
-}
+const transforms = [editorConfig];
 
-export async function toSrc(graph: BuildGraph): Promise<BuildGraph> {
-  // First, normalize line-endings to CRLF
-  const { name, references, from_dependencies } = graph;
-  const components = graph.components.map(component => {
-    const code = component.code;
-    const lines = code.split(BY_LINE);
-
-    component.code = lines.join('\r\n');
-
-    return component;
-  });
-
-  return { name, components, references, from_dependencies };
-}
+export const toCompiled = asyncFlow<BuildGraph>(
+  ...transforms.map(transform => transform.toCompiled).filter(Boolean)
+);
+export const toSrc = asyncFlow<BuildGraph>(
+  ...transforms.map(transform => transform.toSrc).filter(Boolean)
+);

--- a/src/build/transforms/editor-config.ts
+++ b/src/build/transforms/editor-config.ts
@@ -1,0 +1,21 @@
+import { BY_LINE } from '../../utils/text';
+import { BuildGraph } from '../build-graph';
+
+export async function toCompiled(graph: BuildGraph): Promise<BuildGraph> {
+  return graph;
+}
+
+export async function toSrc(graph: BuildGraph): Promise<BuildGraph> {
+  // First, normalize line-endings to CRLF
+  const { name, references, from_dependencies } = graph;
+  const components = graph.components.map(component => {
+    const code = component.code;
+    const lines = code.split(BY_LINE);
+
+    component.code = lines.join('\r\n');
+
+    return component;
+  });
+
+  return { name, components, references, from_dependencies };
+}

--- a/src/build/transforms/editor-config.ts
+++ b/src/build/transforms/editor-config.ts
@@ -1,5 +1,13 @@
+import { KnownProps as EditorConfig, parse } from 'editorconfig';
+import env from '../../env';
+import parallel from '../../utils/parallel';
+import { extname } from '../../utils/path';
 import { BY_LINE } from '../../utils/text';
 import { BuildGraph } from '../build-graph';
+import { Component } from '../component';
+
+const debug = env.debug('vba-blocks:editor-config');
+const cache: Map<string, EditorConfig> = new Map();
 
 export async function toCompiled(graph: BuildGraph): Promise<BuildGraph> {
   return graph;
@@ -8,14 +16,49 @@ export async function toCompiled(graph: BuildGraph): Promise<BuildGraph> {
 export async function toSrc(graph: BuildGraph): Promise<BuildGraph> {
   // First, normalize line-endings to CRLF
   const { name, references, from_dependencies } = graph;
-  const components = graph.components.map(component => {
-    const code = component.code;
-    const lines = code.split(BY_LINE);
-
-    component.code = lines.join('\r\n');
-
-    return component;
-  });
+  const components = await parallel(graph.components, formatComponent);
 
   return { name, components, references, from_dependencies };
+}
+
+async function formatComponent(component: Component): Promise<Component> {
+  const { end_of_line, trim_trailing_whitespace, insert_final_newline } = await loadEditorConfig(
+    component
+  );
+  const new_line = end_of_line === 'lf' ? '\n' : '\r\n';
+
+  const code = component.code;
+  const lines = code.split(BY_LINE);
+  const transformed_code = lines
+    .map(trim_trailing_whitespace ? trimTrailingWhitespace : passthrough)
+    .join(new_line);
+
+  component.code = insert_final_newline ? insertFinalNewline(transformed_code) : transformed_code;
+
+  return component;
+}
+
+async function loadEditorConfig(component: Component): Promise<EditorConfig> {
+  const extension = extname(component.filename);
+  if (cache.has(extension)) return cache.get(extension)!;
+
+  const config = await parse(component.filename);
+  cache.set(extension, config);
+
+  debug(`Formatting ${extension} with`, config);
+
+  return config;
+}
+
+function trimTrailingWhitespace(line: string): string {
+  return line.trimEnd();
+}
+
+function insertFinalNewline(code: string): string {
+  if (code[code.length - 1] !== '\n') code += '\n';
+  return code;
+}
+
+function passthrough(line: string): string {
+  return line;
 }

--- a/src/lockfile/index.ts
+++ b/src/lockfile/index.ts
@@ -1,5 +1,4 @@
 import { ok } from 'assert';
-import { version } from '../../package.json';
 import env from '../env';
 import { CliError, ErrorCode } from '../errors';
 import { Manifest, Snapshot } from '../manifest';
@@ -22,7 +21,6 @@ import { parse as parseToml, toLockfile as convertToLockfileToml } from '../util
 import { Lockfile, LOCKFILE_VERSION } from './lockfile';
 
 const debug = env.debug('vba-blocks:lockfile');
-const VBA_BLOCKS_VERSION = version;
 
 type DependencyByName = Map<string, Dependency>;
 

--- a/src/utils/async-flow.ts
+++ b/src/utils/async-flow.ts
@@ -1,0 +1,11 @@
+// TODO Advanced typing to match input and output type from functions
+// For now, use simple 1-to-1 mapping
+
+type AsyncFn<TValue> = (input: TValue) => Promise<TValue>;
+type Fn<TValue> = (input: TValue) => TValue;
+
+export default function asyncMap<TValue>(
+  ...fns: Array<Fn<TValue> | AsyncFn<TValue>>
+): AsyncFn<TValue> {
+  return value => fns.reduce(async (memo, fn) => fn(await memo), Promise.resolve(value));
+}

--- a/tests/__snapshots__/excel.e2e.ts.snap
+++ b/tests/__snapshots__/excel.e2e.ts.snap
@@ -162,6 +162,7 @@ license = \\"UNLICENSED\\"
 
 exports[`new should create from existing 1`] = `
 Object {
+  ".editorconfig": "[*]{LF}trim_trailing_whitespace = true{LF}insert_final_newline = true{LF}charset = utf-8{LF}{LF}[*.{bas,cls}]{LF}end_of_line = crlf",
   ".gitattributes": "* text=auto{LF}*.bas text eol=crlf{LF}*.cls text eol=crlf",
   ".gitignore": "/build",
   "build/standard.xlsm": "<TODO>",
@@ -210,6 +211,7 @@ VBIDE = { version = \\"5.3\\", guid = \\"{0002E157-0000-0000-C000-000000000046}\
 
 exports[`new should create with blank target 1`] = `
 Object {
+  ".editorconfig": "[*]{LF}trim_trailing_whitespace = true{LF}insert_final_newline = true{LF}charset = utf-8{LF}{LF}[*.{bas,cls}]{LF}end_of_line = crlf",
   ".gitattributes": "* text=auto{LF}*.bas text eol=crlf{LF}*.cls text eol=crlf",
   ".gitignore": "/build",
   "build/blank-target.xlsm": "<TODO>",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "target": "esnext",
-    "lib": ["es2017"],
+    "lib": ["es2019"],
     "skipLibCheck": true,
     "noEmit": true,
     "rootDir": "src",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1579,6 +1579,16 @@ editor@^1.0.0:
   resolved "https://registry.yarnpkg.com/editor/-/editor-1.0.0.tgz#60c7f87bd62bcc6a894fa8ccd6afb7823a24f742"
   integrity sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=
 
+editorconfig@^0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.15.3.tgz#bef84c4e75fb8dcb0ce5cee8efd51c15999befc5"
+  integrity sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==
+  dependencies:
+    commander "^2.19.0"
+    lru-cache "^4.1.5"
+    semver "^5.6.0"
+    sigmund "^1.0.1"
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -3072,6 +3082,14 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+lru-cache@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 macos-release@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
@@ -3782,6 +3800,11 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.3"
 
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
+
 psl@^1.1.24, psl@^1.1.28:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.3.0.tgz#e1ebf6a3b5564fa8376f3da2275da76d875ca1bd"
@@ -4202,6 +4225,11 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
+sigmund@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
+  integrity sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
@@ -4958,6 +4986,11 @@ y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yallist@^3.0.0, yallist@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
Previously, `CRLF` was used for uniformity between Windows and Mac, now that can be configured using `.editorconfig` ([About EditorConfig](https://editorconfig.org)). Additionally, it handles things like removing extraneous trailing whitespace and adding a final newline to files